### PR TITLE
Remove '/web' from directory for static files

### DIFF
--- a/cli/drivers/ContaoValetDriver.php
+++ b/cli/drivers/ContaoValetDriver.php
@@ -25,7 +25,7 @@ class ContaoValetDriver extends ValetDriver
      */
     public function isStaticFile($sitePath, $siteName, $uri)
     {
-        if ($this->isActualFile($staticFilePath = $sitePath.'/web'.$uri)) {
+        if ($this->isActualFile($staticFilePath = $sitePath.$uri)) {
             return $staticFilePath;
         }
 


### PR DESCRIPTION
The files directory in Contao is located outside of the web directory by default.
This will result in an 404 error when trying to access the files this way.
